### PR TITLE
support for slnf

### DIFF
--- a/src/ColorCache.cs
+++ b/src/ColorCache.cs
@@ -45,9 +45,9 @@ namespace SolutionColors
             }
         }
 
-        public static string GetColor(string solutionPath)
+        public static string GetColor(string filePath)
         {
-            int hash = Math.Abs(solutionPath.GetHashCode());
+            int hash = Math.Abs(filePath.GetHashCode());
             int mod = hash % ColorMap.Count;
 
             return ColorMap.Keys.ElementAt(mod);

--- a/src/SolutionColors.csproj
+++ b/src/SolutionColors.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Commands\SetColorCommandSolution.cs" />
     <Compile Include="SolutionColorsPackage.cs" />
+    <Compile Include="SolutionStuff.cs" />
     <Compile Include="source.extension.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/SolutionStuff.cs
+++ b/src/SolutionStuff.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace SolutionColors
+{
+    internal class SolutionStuff
+    {
+        private const string Dotslnf = ".slnf";
+
+        /// <summary>
+        /// Return solution filter (slnf) name if slnf is opened, otherwise return solution (sln) name.
+        /// </summary>
+        public static async Task<string> GetSolutionNameAsync()
+        {
+            //check for opened solution filter (slnf)
+            //if slnf exists, use it instead of solution name
+            IVsSolution vss = AsyncPackage.GetGlobalService(typeof(SVsSolution)) as IVsSolution;
+            vss.GetSolutionInfo(out string a, out string b, out string c);
+            if (!string.IsNullOrEmpty(c) && c.Contains(Dotslnf))
+            {
+                //cut slnf file name from
+                int right = c.LastIndexOf(Dotslnf);
+                c = c.Substring(0, right + Dotslnf.Length);
+                if (c.Contains("\\"))
+                {
+                    int left = c.LastIndexOf("\\");
+                    c = c.Substring(left + 1);
+                }
+                else if (c.Contains("/")) //visual studio is not a crossplatform app, but for additional sure check the different separator
+                {
+                    int left = c.LastIndexOf("/");
+                    c = c.Substring(left + 1);
+                }
+
+                return c;
+            }
+
+            Solution sol = await VS.Solutions.GetCurrentSolutionAsync();
+            return sol.Name;
+        }
+
+        /// <summary>
+        /// Return solution filter (slnf) name(!) if slnf is opened, otherwise return solution (sln) path(!).
+        /// </summary>
+        public static async Task<string> GetSolutionPathAsync()
+        {
+            //check for opened solution filter (slnf)
+            //if slnf exists, use it instead of solution name
+            IVsSolution vss = AsyncPackage.GetGlobalService(typeof(SVsSolution)) as IVsSolution;
+            vss.GetSolutionInfo(out string a, out string b, out string c);
+            if (!string.IsNullOrEmpty(c) && c.Contains(Dotslnf))
+            {
+                //cut slnf file name from
+                int right = c.IndexOf(Dotslnf);
+                c = c.Substring(0, right + Dotslnf.Length);
+                if (c.Contains("\\"))
+                {
+                    int left = c.LastIndexOf("\\");
+                    c = c.Substring(left + 1);
+                }
+                else if (c.Contains("/")) //visual studio is not a crossplatform app, but for additional sure check the different separator
+                {
+                    int left = c.LastIndexOf("/");
+                    c = c.Substring(left + 1);
+                }
+
+                return c; //here we use only a slnf NAME, not a slnf PATH, due to: https://developercommunity.visualstudio.com/t/no-way-to-get-path-to-solution-filter-fi/1520237
+            }
+
+            Solution sol = await VS.Solutions.GetCurrentSolutionAsync();
+            return sol.FullPath;
+        }
+    }
+}


### PR DESCRIPTION
Fix #8 (partially).

If VS works with slnf, then use slnf file **name** instead of solution name/path. Such fix allows to set different colors to different slnfs.

Additional note

There are troubles to obtain slnf name (and slnf full path expecially!), please [refer](https://developercommunity.visualstudio.com/t/no-way-to-get-path-to-solution-filter-fi/1520237). The way I get slnf NAME is ugly, but the way to get slnf FULL PATH is **completely horrible**, so I decided to use slnf name only. If there will be a way to get slnf full path in normal way, the code will need a small fix (in `SolutionStuff` file). Mads, could I ask to you to try to push that ticket forward? :) Probably we need a new way to get such info into our VSIXes.
