### PR TITLE
Fix hidden Border Settings dialog on high DPI displays

### DIFF
--- a/src/Options/BorderEditorDialog.Designer.cs
+++ b/src/Options/BorderEditorDialog.Designer.cs
@@ -200,6 +200,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoSize = true;
             this.ClientSize = new System.Drawing.Size(216, 291);
             this.ControlBox = false;
             this.Controls.Add(this.numBottom);


### PR DESCRIPTION
- Set the AutoSize property for the border settings form to true.