### PR TITLE
Feat: Support VS2022 Preview new UI

### DIFF
--- a/src/ColorHelper.cs
+++ b/src/ColorHelper.cs
@@ -465,7 +465,7 @@ namespace SolutionColors
 
             if (_solutionLabel == null)
             {
-                _solutionLabel = Application.Current.MainWindow.FindChild<Border>("TextBorder");
+                _solutionLabel = Application.Current.MainWindow.FindChild<Border>("PART_SolutionNameTextBlock").Parent as Border;
                 _originalLabelColor = _solutionLabel?.Background;
             }
 


### PR DESCRIPTION
This closes #29 

I compared the visual trees between 2022 preview (left) <--> 2022 non-preview.
![image](https://github.com/madskristensen/SolutionColors/assets/42881734/602ddcc6-4e73-4f05-8917-08430e4f37fa)

They renamed the `Border` control, and we cannot use the `ControlBorder` as the name to find it because there are tons of other borders named the same. The solution is simply find the uniquely-named part, then get its parent.

2022 release ver:
![image](https://github.com/madskristensen/SolutionColors/assets/42881734/7daceabe-050c-41c3-8618-02176deaca09)

2022 preview:
![image](https://github.com/madskristensen/SolutionColors/assets/42881734/ca8482cc-4274-45a9-ab13-4d0e5c85a90e)

