### PR TITLE
Add arm64 support

### DIFF
--- a/src/SolutionColors.csproj
+++ b/src/SolutionColors.csproj
@@ -123,7 +123,7 @@
       <Version>16.0.59</Version>
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.2.2195">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.8.2365">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -14,6 +14,10 @@
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
+      <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
+        <ProductArchitecture>arm64</ProductArchitecture>
+      </InstallationTarget>
+
     </Installation>
     <Prerequisites>
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
Added arm64 support with the help of this article: https://devblogs.microsoft.com/visualstudio/now-introducing-arm64-support-for-vs-extensions/

The SolutionColors extension now works just fine on my Apple Silicon Macbook Pro (M2 Pro).