### PR TITLE
Fixed issue with automatic coloring not always working

### DIFF
--- a/src/ColorCache.cs
+++ b/src/ColorCache.cs
@@ -55,7 +55,7 @@ namespace SolutionColors
         public static string GetColor(string filePath)
         {
             int hash = Math.Abs(filePath.GetHashCode());
-            int mod = hash % ColorMap.Count - 1;    //last one is "None" which is not a valid color
+            int mod = hash % (ColorMap.Count - 1);    //last one is "None" which is not a valid color
 
             return ColorMap[ColorMap.Keys.ElementAt(mod)];
         }


### PR DESCRIPTION
There was an issue where operator precedence wasn't taken into account.