### PR TITLE
Add git worktree support for branch detection

### DIFF
--- a/src/GitHelper.cs
+++ b/src/GitHelper.cs
@@ -36,6 +36,17 @@ namespace SolutionColors
                     string content = File.ReadAllText(Path.Combine(directoryInfo.FullName, ".git", "HEAD"));
                     return content.Replace("ref: refs/heads/", "").Trim();
                 }
+
+                // git worktree support
+                if (File.Exists(Path.Combine(directoryInfo.FullName, ".git")))
+                {
+                    string gitFileContent = File.ReadAllText(Path.Combine(directoryInfo.FullName, ".git"));
+                    string worktreeDir = gitFileContent.Replace("gitdir: ", "").Trim();
+
+                    string content = File.ReadAllText(Path.Combine(worktreeDir, "HEAD"));
+                    return content.Replace("ref: refs/heads/", "").Trim();
+                }
+
                 directoryInfo = System.IO.Directory.GetParent(directoryInfo.FullName);
             }
 


### PR DESCRIPTION
Hi there,

Really like the extension. I thought I'd add a small change to support branches that have been checked out via git worktree to support my use-case.

The current GitHelper.cs implementation only looks for .git folders, whereas git worktree adds a .git file to the base directory that points to a git/worktrees folder with the branch's name. My small addition checks for a worktree file if it can't find a .git folder.

It's based on your existing code but let me know if there's anything else I can add to the PR!

