### PR TITLE
Fix #52, extension not working if color.txt doesn’t include master color

### DIFF
--- a/src/ColorHelper.cs
+++ b/src/ColorHelper.cs
@@ -211,7 +211,7 @@ namespace SolutionColors
         public static string GetFileName(bool isColor = true)
         {
             // This is bad practice but doesn't introduce any noticable hitch and is much easier than reengineering everything
-            Task<string> iconNameTask = GetFileNameAsync(false);
+            Task<string> iconNameTask = GetFileNameAsync(isColor);
             iconNameTask.Wait();
             return (iconNameTask.Result != null) ? iconNameTask.Result : "";
         }

--- a/src/ColorHelper.cs
+++ b/src/ColorHelper.cs
@@ -304,7 +304,14 @@ namespace SolutionColors
             }
             else
             {
-                colorMaster = (Color)ColorConverter.ConvertFromString(ColorCache.GetColorCode(await GetColorAsync("master")));
+                try
+                {
+                    colorMaster = (Color)ColorConverter.ConvertFromString(ColorCache.GetColorCode(await GetColorAsync("master")));
+                }
+                catch(FormatException)
+                {
+                    colorMaster = Colors.Black;
+                }
             }
 
             Color colorBranch;


### PR DESCRIPTION
I surrounded the faulty line with a try catch and default `colorMaster` to black.

I also found that `GetFileName` didn’t pass `isColor` argument to `GetFileNameAsync` and corrected it.

This fixes #52 and probably also #50.